### PR TITLE
GetFilesAsync should return without exception if path does not exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- Updated `GetFilesAsync` in the `FileSystem` implementation so that it doesn't throw an exception if the path doesn't
+  exist, making it consistent with the other implementations.
+
 ## [3.1.0]
 
 ### Changed
@@ -14,7 +21,9 @@
 
 ### Changed
 
-- **Breaking change** This release changes how paths are built when using Azure Blob Storage in order to avoid platform inconsistencies. It's possible this could result in `FileExistsAsync` and `GetFilesAsync` failing for existing files. Thorough testing is recommended when updating.
+- **Breaking change** This release changes how paths are built when using Azure Blob Storage in order to avoid platform
+  inconsistencies. It's possible this could result in `FileExistsAsync` and `GetFilesAsync` failing for existing files.
+  Thorough testing is recommended when updating.
 
 ## [2.1.0]
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ builder.Services.AddSingleton<IFileService, InMemoryFileService>();
 ### File System
 
 The file system service writes files to a local or network drive. The `basePath` parameter is required and defines where
-the files will be stored.
+the files will be stored. If `basePath` doesn't exist, it will be created.
 
 ```csharp
 builder.Services.AddTransient<IFileService, FileSystemFileService>(_ =>

--- a/src/FileService/Implementations/FileSystem.cs
+++ b/src/FileService/Implementations/FileSystem.cs
@@ -81,9 +81,11 @@ public class FileSystem : IFileService
 #pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
     {
         var fullBasePath = $"{new DirectoryInfo(_basePath).FullName}{Path.DirectorySeparatorChar}";
+        var directoryInfo = new DirectoryInfo(Path.Combine(_basePath, path));
+        if (!directoryInfo.Exists) yield break;
 
-        foreach (var fileInfo in new DirectoryInfo(Path.Combine(_basePath, path))
-                     .EnumerateFiles("*", new EnumerationOptions { RecurseSubdirectories = true }))
+        foreach (var fileInfo in directoryInfo.EnumerateFiles("*",
+                     new EnumerationOptions { RecurseSubdirectories = true }))
         {
             yield return new IFileService.FileDescription
             {

--- a/tests/FileService.Tests/FileSystemTests.cs
+++ b/tests/FileService.Tests/FileSystemTests.cs
@@ -137,7 +137,18 @@ public class FileSystemTests
         var results = _fileService.GetFilesAsync();
 
         // Assert
-        await foreach (var unused in results) Assert.Fail("`results` should be empty.");
+        await foreach (var _ in results) Assert.Fail("`results` should be empty.");
+        Assert.Pass("`results` is empty.");
+    }
+
+    [Test]
+    public async Task GetFiles_WhenPathDoesNotExist_ReturnsEmptyList()
+    {
+        // Act
+        var results = _fileService.GetFilesAsync("nope");
+
+        // Assert
+        await foreach (var _ in results) Assert.Fail("`results` should be empty.");
         Assert.Pass("`results` is empty.");
     }
 

--- a/tests/FileService.Tests/InMemoryTests.cs
+++ b/tests/FileService.Tests/InMemoryTests.cs
@@ -130,7 +130,7 @@ public class InMemoryTests
         var results = _fileService.GetFilesAsync();
 
         // Assert
-        await foreach (var unused in results) Assert.Fail("`results` should be empty.");
+        await foreach (var _ in results) Assert.Fail("`results` should be empty.");
         Assert.Pass("`results` is empty.");
     }
 


### PR DESCRIPTION
This PR updates the `FileSystem` implementation to return without exception from `GetFilesAsync` if the path does not exist, making it consistent with the In Memory and Azure Blob Storage implementations.